### PR TITLE
Improved label parsing

### DIFF
--- a/src/sic/asm/AsmError.java
+++ b/src/sic/asm/AsmError.java
@@ -8,6 +8,7 @@ package sic.asm;
 public class AsmError extends Exception implements Comparable<AsmError> {
 
     public final Location loc;
+    private boolean nonBreaking = false;
 
     public AsmError(Location loc, String msg) {
         super(msg);
@@ -22,9 +23,15 @@ public class AsmError extends Exception implements Comparable<AsmError> {
         this(null, format, objs);
     }
 
+    public AsmError(Location loc, boolean nonBreaking, String format, Object... objs) {
+        this(loc, String.format(format, objs));
+        this.nonBreaking = nonBreaking;
+    }
+
     @Override
     public String toString() {
-        String head = "Error" + (loc != null ? " at " + loc + " (" + loc.pos + ")" : "");
+        String severity = isBreaking() ? "Error" : "Warning";
+        String head = severity + (loc != null ? " at " + loc + " (" + loc.pos + ")" : "");
         String message = this.getLocalizedMessage();
         return ((message != null) ? (head + ": " + message) : head) + ".";
     }
@@ -32,6 +39,10 @@ public class AsmError extends Exception implements Comparable<AsmError> {
     @Override
     public int compareTo(AsmError that) {
         return this.loc.pos - that.loc.pos;
+    }
+
+    public boolean isBreaking() {
+        return !nonBreaking;
     }
 
 }

--- a/src/sic/asm/ErrorCatcher.java
+++ b/src/sic/asm/ErrorCatcher.java
@@ -42,11 +42,7 @@ public class ErrorCatcher {
     public void print() {
         for ( ; lastPrinted < errs.size(); lastPrinted++) {
             AsmError err = errs.get(lastPrinted);
-            if (err.isBreaking()) {
-                System.err.println(err);
-            } else {
-                System.out.println(err);
-            }
+            System.err.println(err);
         }
     }
 

--- a/src/sic/asm/ErrorCatcher.java
+++ b/src/sic/asm/ErrorCatcher.java
@@ -47,10 +47,7 @@ public class ErrorCatcher {
     }
 
     public boolean shouldEnd() {
-        for (AsmError err : errs) {
-            if (err.isBreaking()) return true;
-        }
-        return false;
+        return errs.stream().anyMatch(AsmError::isBreaking);
     }
 
 }

--- a/src/sic/asm/ErrorCatcher.java
+++ b/src/sic/asm/ErrorCatcher.java
@@ -42,8 +42,19 @@ public class ErrorCatcher {
     public void print() {
         for ( ; lastPrinted < errs.size(); lastPrinted++) {
             AsmError err = errs.get(lastPrinted);
-            System.err.println(err);
+            if (err.isBreaking()) {
+                System.err.println(err);
+            } else {
+                System.out.println(err);
+            }
         }
+    }
+
+    public boolean shouldEnd() {
+        for (AsmError err : errs) {
+            if (err.isBreaking()) return true;
+        }
+        return false;
     }
 
 }

--- a/src/sic/asm/parsing/Lexer.java
+++ b/src/sic/asm/parsing/Lexer.java
@@ -36,10 +36,14 @@ public class Lexer extends Input {
 
     public String skipLinesAndComments() {
         StringBuilder comments = new StringBuilder();
-        while (isWhitespace() || isNewLine()) {
-            advance();
-            comments.append(readIfComment(true, true));
-            comments.append('\n');
+        while (isWhitespace() || isNewLine() || peek() == '.') {
+            String comment = readIfComment(true, true);
+            if (comment != null) {
+                comments.append(comment);
+                comments.append('\n');
+            } else {
+                advance();
+            }
         }
         return comments.length() > 0 ? comments.toString() : null;
     }

--- a/src/sic/asm/parsing/Lexer.java
+++ b/src/sic/asm/parsing/Lexer.java
@@ -24,10 +24,24 @@ public class Lexer extends Input {
         return Character.isLetterOrDigit(peek()) || peek() == '_';
     }
 
+    public boolean isNewLine() {
+        return peek() == '\n';
+    }
+
     // ************ advance and read
 
     public void skipWhitespace() {
         while (isWhitespace()) advance();
+    }
+
+    public String skipLinesAndComments() {
+        StringBuilder comments = new StringBuilder();
+        while (isWhitespace() || isNewLine()) {
+            advance();
+            comments.append(readIfComment(true, true));
+            comments.append('\n');
+        }
+        return comments.length() > 0 ? comments.toString() : null;
     }
 
     public void skipAlphanumeric() {

--- a/src/sic/asm/parsing/OperandParser.java
+++ b/src/sic/asm/parsing/OperandParser.java
@@ -141,7 +141,7 @@ public class OperandParser {
         if (Character.isDigit(parser.peek()) || parser.peek() == '-') {
             operand = parser.readInt(flags.minOperand(), flags.maxOperand());
             symbol = null;
-        } else if (Character.isLetter(parser.peek())) {
+        } else if (Character.isLetter(parser.peek()) || parser.peek() == '_') {
             operand = 0;
             symbol = parser.readSymbol();
         } else if (parser.peek() == '*') {
@@ -179,7 +179,7 @@ public class OperandParser {
         if (Character.isDigit(parser.peek()) || parser.peek() == '-') {
             operand = parser.readInt(flags.minOperand(), flags.maxOperand());
             symbol = null;
-        } else if (Character.isLetter(parser.peek())) {
+        } else if (Character.isLetter(parser.peek()) || parser.peek() == '_') {
             operand = 0;
             symbol = parser.readSymbol();
         } else if (parser.peek() == '*') {

--- a/src/sic/asm/parsing/Parser.java
+++ b/src/sic/asm/parsing/Parser.java
@@ -34,15 +34,20 @@ public class Parser extends Lexer {
     }
 
     public void checkWhitespace(String fmt, Object... objs) throws AsmError {
-        if (Options.requireWhitespace && !Character.isWhitespace(prev))
-            throw new AsmError(loc(), fmt, objs);
+        if (Options.requireWhitespace) {
+            if (available() <= 0) throw new AsmError(loc(), true,"Empty label %s at the end", objs);
+            if (!Character.isWhitespace(prev)) throw new AsmError(loc(), fmt, objs);
+        }
     }
 
     public Command parseIfCommand() throws AsmError {
         Location loc = loc();
         String label = readIfLabel();
         skipWhitespace();
-        if (label != null) checkWhitespace("Missing whitespace after label '%s'", label);
+        if (label != null) {
+            skipLinesAndComments();
+            checkWhitespace("Missing whitespace after label '%s'", label);
+        }
         else loc = loc();
         String name = readIfMnemonic();
         if (name == null) {

--- a/src/sic/sim/MainView.java
+++ b/src/sic/sim/MainView.java
@@ -1,5 +1,6 @@
 package sic.sim;
 
+import sic.asm.AsmError;
 import sic.asm.Assembler;
 import sic.asm.ErrorCatcher;
 import sic.ast.Program;
@@ -310,7 +311,9 @@ public class MainView {
         Program program = assembler.assemble(Utils.readFile(file));
         if (errorCatcher.count() > 0) {
             errorCatcher.print();
-            return;
+            if (errorCatcher.shouldEnd()) {
+                return;
+            }
         }
 
         Writer writer = new StringWriter();


### PR DESCRIPTION
With this PR, SicTools allows more styles of using labels.

**Labels in new lines**
Currently, only this was allowed:
```
Label    LDA #10   . Comment
```
Now SicTools also allows the following examples:
```
Label              
         LDA #10   . Comment
```
```
Label              . Comment
         LDA #10   
```

 **Labels at the end of files**
Label can also be empty if at the end of file, in which case SicTools now emits a warning but still parses the file.

 **Support for labels with underscores**
Labels can now contain the underscore character, which was previously not allowed as an operand in instructions.

**LLVM**
With this patch, SicTools becomes compatible with [sic-llvm](https://github.com/jakoberzar/sic-llvm) and [sic-clang](https://github.com/jakoberzar/sic-clang). Therefore compiling from C and compilers with proper LLVM IR output becomes possible.