### PR TITLE
file devices get reset with simulated program

### DIFF
--- a/src/sic/sim/MainView.java
+++ b/src/sic/sim/MainView.java
@@ -213,6 +213,7 @@ public class MainView {
             public void actionPerformed(ActionEvent actionEvent) {
                 executor.getMachine().registers.reset();
                 executor.getMachine().memory.reset();
+                executor.getMachine().devices.reset();
                 loadLastLoaded();
                 updateView();
             }

--- a/src/sic/sim/vm/Device.java
+++ b/src/sic/sim/vm/Device.java
@@ -18,4 +18,7 @@ public class Device {
     public void write(int value) {
     }
 
+    public void reset() {
+    }
+
 }

--- a/src/sic/sim/vm/Devices.java
+++ b/src/sic/sim/vm/Devices.java
@@ -51,6 +51,12 @@ public class Devices {
         return devices[idx].test();
     }
 
+    public void reset() {
+        for (int i = SICXE.DEVICE_FREE; i < devices.length; i++) {
+            devices[i].reset();
+        }
+    }
+
     public Devices(int count) {
         assert count > 2;
         devices = new Device[count];

--- a/src/sic/sim/vm/FileDevice.java
+++ b/src/sic/sim/vm/FileDevice.java
@@ -45,6 +45,16 @@ public class FileDevice extends Device {
         }
     }
 
+    @Override
+    public void reset() {
+        if (file == null) return;
+        try {
+            file.seek(0);
+        } catch (IOException e) {
+            Logger.fmterr("Cannot reset file '%s'", filename);
+        }
+    }
+
     public FileDevice(String filename) {
         this.filename = filename;
         // do not open/create file - lazy open


### PR DESCRIPTION
If clear&reload is run in the simulator, all FileDevices start reading and writing from the start (same behavoir as if the simulator were restarted).