### PR TITLE
Fixed ORG assembler directive to correctly set the address

### DIFF
--- a/src/sic/asm/visitors/WriteText.java
+++ b/src/sic/asm/visitors/WriteText.java
@@ -87,15 +87,16 @@ public class WriteText extends WriteVisitor {
 
     public void visit(Command c) throws AsmError {
         if (c.size() > 0) buf.append(space);
+        
+        if (recordBytes == 0)
+            textAddr = program.locctr();
 
         int bufLenBefore = buf.length();
         boolean flush = c.emitText(buf);
         recordBytes += (buf.length() - bufLenBefore) / 2;
 
-        if (flush || recordBytes > 28) {
+        if (flush || recordBytes > 28)
             flushBuf();
-            textAddr = program.locctr() + c.size();
-        }
     }
 
     public void visit(DirectiveORG d) {


### PR DESCRIPTION
Fixed ORG assembler directive to correctly set the address of the block following this directive. See tests org.asm, addr-simple.asm, blocks-org.asm and resolve-cycle.asm and their respective object codes for the difference.