### PR TITLE
Fixed FileDevice reset when device file was deleted.

### DIFF
--- a/src/sic/sim/vm/FileDevice.java
+++ b/src/sic/sim/vm/FileDevice.java
@@ -49,7 +49,8 @@ public class FileDevice extends Device {
     public void reset() {
         if (file == null) return;
         try {
-            file.seek(0);
+            file.close();
+            file = null;
         } catch (IOException e) {
             Logger.fmterr("Cannot reset file '%s'", filename);
         }


### PR DESCRIPTION
Deleting open `XX.dev` files on linux causes no exceptions. File remains open and java happily writes to a non existing file. 

Since `RandomAccessFile` class does not have `.exists()` method this problem is solved by closing the file descriptor and setting `file` back to null when resetting the device. This helps avoid unnecessary program restarts.