### PR TITLE
[GUI] Prompting errors when it fails to load.

### DIFF
--- a/src/sic/asm/ErrorCatcher.java
+++ b/src/sic/asm/ErrorCatcher.java
@@ -39,11 +39,14 @@ public class ErrorCatcher {
                 System.err.println(err);
     }
 
-    public void print() {
+    public String print() {
+	String allErrs="";
         for ( ; lastPrinted < errs.size(); lastPrinted++) {
             AsmError err = errs.get(lastPrinted);
             System.err.println(err);
+	    allErrs+=(err+"\n");
         }
+	return allErrs;
     }
 
     public boolean shouldEnd() {

--- a/src/sic/sim/MainView.java
+++ b/src/sic/sim/MainView.java
@@ -71,7 +71,7 @@ public class MainView {
         mainPanel.add(westPanel, BorderLayout.WEST);
         mainPanel.add(eastPanel, BorderLayout.CENTER);
 
-        mainFrame = new JFrame("SicTools");
+        mainFrame = new JFrame("SicTools_Modified_By_HassanAli");
         mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         mainFrame.setJMenuBar(createMenuBar());
         mainFrame.setContentPane(mainPanel);
@@ -331,7 +331,14 @@ public class MainView {
         ErrorCatcher errorCatcher = assembler.errorCatcher;
         Program program = assembler.assemble(Utils.readFile(file));
         if (errorCatcher.count() > 0) {
-            errorCatcher.print();
+            String allErrs = errorCatcher.print();
+	    JTextArea errArea = new JTextArea(allErrs);
+            JScrollPane scrollPane = new JScrollPane(errArea);
+            errArea.setLineWrap(true);
+            errArea.setWrapStyleWord(true);
+            scrollPane.setPreferredSize(new Dimension( 250, 250 ));
+            JOptionPane.showMessageDialog(mainFrame, scrollPane, "Error", JOptionPane.INFORMATION_MESSAGE);
+            updateView();
             if (errorCatcher.shouldEnd()) {
                 return;
             }


### PR DESCRIPTION
Due to the inconvenience of the Error handling process of SicTools. I've made some modifications that prompts all errors found in a .asm file when the simulator fails to load the file other than just printing those errors in a command line. because, sometimes windows users for example run the simulator from just double clicking on sic.jar file. so, they can't see the errors when they have ones because there is no cmd or a terminal running to show these errors.