### PR TITLE
Direct addressing broken when using EQU expresions

### DIFF
--- a/src/sic/ast/instructions/InstructionF4m.java
+++ b/src/sic/ast/instructions/InstructionF4m.java
@@ -31,6 +31,8 @@ public class InstructionF4m extends InstructionF34Base {
                 program.section().addRelocation(program.locctr() + 1, 5, '+', symbol);
             else
                 program.section().addRelocation(program.locctr() + 1, 5);
+
+            return resolvedValue >= flags.minOperand() && resolvedValue <= flags.maxOperand();
         }
         return true;
     }


### PR DESCRIPTION
```asm
prog	START	0
	LDA	#number
halt	J	halt
	END	prog

number	EQU	0x0A000
```
When loading this program the assembler does not give any errors, even though the number here is out of range for format 3. It proceeds by masking the lower bits making the `LDA #number` statement equivalent to `LDA #0`.

In contrast, the following program gives "number out of range" error.
```asm
prog	START	0
	LDA	#0x0A000
halt	J	halt
	END	prog
```

The same goes for format 4 with one change to how negative numbers are handled. Currently it fails to assemble `+LDA #-1` with "number out of range" error, but accepts `EQU` defined negative numbers without any problems (`+LDA #number`). With this change (different) errors are thrown which help keep the limitation consistent.

In both formats assembly now fails with `Cannot reference symbol` exception.