### PR TITLE
Added EXTREF and EXTDEF symbol length checking

### DIFF
--- a/src/sic/asm/parsing/OperandParser.java
+++ b/src/sic/asm/parsing/OperandParser.java
@@ -35,10 +35,15 @@ public class OperandParser {
         parser.checkWhitespace("Missing whitespace after mnemonic '%s'", name);
     }
 
-    private List<String> parseSymbols() throws AsmError {
+    private List<String> parseSymbols(int maxLength) throws AsmError {
         List<String> syms = new ArrayList<String>();
-        do
-            syms.add(parser.readSymbol());
+        String sym;
+        do {
+            sym = parser.readSymbol();
+            if (sym.length() > maxLength)
+                throw new AsmError(parser.loc(), "Symbol name '%s' too long", sym);
+            syms.add(sym);
+        }
         while (parser.skipIfComma());
         return syms;
     }
@@ -225,12 +230,7 @@ public class OperandParser {
     }
 
     private Command parseDs_(Location loc, String label, Mnemonic mnemonic) throws AsmError {
-        List<String> names = parseSymbols();
-        // object files require external symbols to be at most 6 characters long
-        for (String name : names) {
-            if (name.length() > 6)
-                throw new AsmError(loc, "Symbol name '%s' too long", name);
-        }
+        List<String> names = parseSymbols(6);
         switch (mnemonic.opcode) {
             case Opcode.EXTDEF: return new DirectiveEXTDEF(loc, label, mnemonic, names);
             case Opcode.EXTREF: return new DirectiveEXTREF(loc, label, mnemonic, names);

--- a/src/sic/asm/parsing/OperandParser.java
+++ b/src/sic/asm/parsing/OperandParser.java
@@ -226,7 +226,7 @@ public class OperandParser {
 
     private Command parseDs_(Location loc, String label, Mnemonic mnemonic) throws AsmError {
         List<String> names = parseSymbols();
-        // .obj files only support symbols in 'R' section with at most 6 characters
+        // object files require external symbols to be at most 6 characters long
         for (String name : names) {
             if (name.length() > 6)
                 throw new AsmError(loc, "Symbol name '%s' too long", name);

--- a/src/sic/asm/parsing/OperandParser.java
+++ b/src/sic/asm/parsing/OperandParser.java
@@ -226,6 +226,11 @@ public class OperandParser {
 
     private Command parseDs_(Location loc, String label, Mnemonic mnemonic) throws AsmError {
         List<String> names = parseSymbols();
+        // .obj files only support symbols in 'R' section with at most 6 characters
+        for (String name : names) {
+            if (name.length() > 6)
+                throw new AsmError(loc, "Symbol name '%s' too long", name);
+        }
         switch (mnemonic.opcode) {
             case Opcode.EXTDEF: return new DirectiveEXTDEF(loc, label, mnemonic, names);
             case Opcode.EXTREF: return new DirectiveEXTREF(loc, label, mnemonic, names);


### PR DESCRIPTION
Linker relies on `EXTREF` symbol names to be at most 6 characters long. This is not obvious when assembling file that contains `EXTREF <symbol longer than 6 characters>`. Object file is created with corrupted `R` section where it's no longer guaranteed that it is divisible by 6 which causes `IndexOutOfBounds` exception and even if it happens to be, it fails to give the proper reason why it failed to find its definition. 

This is now fixed with assembler throwing `Symbol name too long` exception beforehand preventing further confusion.