### PR TITLE
Clear labels when clearing memory

### DIFF
--- a/src/sic/sim/MainView.java
+++ b/src/sic/sim/MainView.java
@@ -120,6 +120,7 @@ public class MainView {
 
     public void updateView() {
         cpuView.updateView();
+        disassemblyView.clearLabelMap();
         disassemblyView.updateView(!executor.isRunning(), !executor.isRunning());
         memoryView.updateView();
         watchView.updateView();

--- a/src/sic/sim/MainView.java
+++ b/src/sic/sim/MainView.java
@@ -191,6 +191,7 @@ public class MainView {
                 executor.getMachine().registers.reset();
                 executor.getMachine().memory.reset();
                 disassemblyView.clearLabelMap();
+                watchView.clearLabelMap();
                 updateView();
             }
         });
@@ -206,6 +207,7 @@ public class MainView {
             public void actionPerformed(ActionEvent actionEvent) {
                 executor.getMachine().memory.reset();
                 disassemblyView.clearLabelMap();
+                watchView.clearLabelMap();
                 updateView();
             }
         });

--- a/src/sic/sim/MainView.java
+++ b/src/sic/sim/MainView.java
@@ -120,7 +120,6 @@ public class MainView {
 
     public void updateView() {
         cpuView.updateView();
-        disassemblyView.clearLabelMap();
         disassemblyView.updateView(!executor.isRunning(), !executor.isRunning());
         memoryView.updateView();
         watchView.updateView();
@@ -191,6 +190,7 @@ public class MainView {
             public void actionPerformed(ActionEvent actionEvent) {
                 executor.getMachine().registers.reset();
                 executor.getMachine().memory.reset();
+                disassemblyView.clearLabelMap();
                 updateView();
             }
         });
@@ -205,6 +205,7 @@ public class MainView {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 executor.getMachine().memory.reset();
+                disassemblyView.clearLabelMap();
                 updateView();
             }
         });


### PR DESCRIPTION
"Clear memory" and "Clear all" buttons do not clear the label column of the disassembly view.
![image](https://user-images.githubusercontent.com/18378617/198870304-d4c01ccf-7b22-481b-9442-c35f204fa7da.png)

This PR adds a call to `clearLabelMap()` method, which will delete all old labels before refreshing the disassembly view.
