### PR TITLE
Add scrolling to `DissasemblyView` and `MemoryView`

### DIFF
--- a/src/sic/sim/views/DisassemblyView.java
+++ b/src/sic/sim/views/DisassemblyView.java
@@ -254,6 +254,11 @@ public class DisassemblyView {
             if (loc > SICXE.MAX_ADDR) clearDisLine(row);
             else {
                 if (selectPC && loc == machine.registers.getPC()) {
+                    if (getAddressAtRow(tabDis.getRowCount() - 2) == machine.registers.getPC()) {
+                        disMove(1);
+                        updateDis(true, false);
+                        return;
+                    }
                     tabDis.setRowSelectionInterval(row, row);
                     followPC = false;
                 }

--- a/src/sic/sim/views/MemoryView.java
+++ b/src/sic/sim/views/MemoryView.java
@@ -7,8 +7,7 @@ import sic.sim.Executor;
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.awt.event.*;
 
 /**
  * TODO: write a short description
@@ -85,6 +84,14 @@ public class MemoryView {
                 updateView();
             }
         };
+        hex.addMouseWheelListener(new MouseAdapter() {
+            @Override
+            public void mouseWheelMoved(MouseWheelEvent evt) {
+                hex.moveStartAddress(evt.getWheelRotation() > 0 ? 1 : -1);
+                hex.requestFocus();
+                updateView();
+            }
+        });
     }
 
     public void updateView() {


### PR DESCRIPTION
This commit adds scroll wheel listeners to
`DissasemblyView`  and `MemoryView` which move the view up or down.

Additionaly this PR scrolls `DissasemblyView` down when stepping through code if PC is close to the bottom row. This makes it easier to follow the program flow :^)