### PR TITLE
Fix bug in `Machine` where float counts as 3 bytes.

### DIFF
--- a/src/sic/sim/vm/Machine.java
+++ b/src/sic/sim/vm/Machine.java
@@ -147,7 +147,7 @@ public class Machine {
     private double loadFloat(Flags flags, int operand) throws ReadDataBreakpointException {
         if (flags.isImmediate()) return operand;
         int addr = resolveAddr(flags, operand);
-        setLastExecRead(addr, 3);
+        setLastExecRead(addr, 6);
         return memory.getFloat(addr);
     }
 
@@ -170,7 +170,7 @@ public class Machine {
 
     private void storeFloat(Flags flags, int operand, double _float) throws WriteDataBreakpointException {
         int addr = resolveAddr(flags, operand);
-        setLastExecWrite(addr, 3);
+        setLastExecWrite(addr, 6);
         memory.setFloat(addr, _float);
     }
 


### PR DESCRIPTION
This didn't break execution of the program, but it did return only 3 bytes in `lastExecRead/Write` instead of 6.

Bug was introduced with PR #36 and didn't notice it until it was merged.