### PR TITLE
add option for indirect index addressing

### DIFF
--- a/src/sic/Asm.java
+++ b/src/sic/Asm.java
@@ -44,7 +44,8 @@ public class Asm {
         "    -space-require     Require whitespace after labels and mnemonics.\n" +
         "    -space-forgo\n" +
         "    -comment-dot-require  Require dots in comments.\n" +
-        "    -comment-dot-forgo.\n"
+        "    -comment-dot-forgo.\n" +
+        "    -indirect-x        Allow indirect indexed addressing.\n"
         );
     }
 
@@ -73,6 +74,7 @@ public class Asm {
             if ("-space-forgo".equals(arg)) Options.requireWhitespace = false;
             if ("-comment-dot-require".equals(arg)) Options.requireCommentDot = true;
             if ("-comment-dot-forgo".equals(arg)) Options.requireCommentDot = false;
+            if ("-indirect-x".equals(arg)) Options.indirectX = true;
             if (!arg.startsWith("-")) break;
             last++;
         }

--- a/src/sic/asm/Options.java
+++ b/src/sic/asm/Options.java
@@ -15,4 +15,5 @@ public class Options {
     // obj generator
     public static boolean addSpaceInObj = false;       // add space between fields in obj files
 
+    public static boolean indirectX = false;           // allow indirect indexed addressing
 }

--- a/src/sic/asm/parsing/OperandParser.java
+++ b/src/sic/asm/parsing/OperandParser.java
@@ -2,6 +2,7 @@ package sic.asm.parsing;
 
 import sic.asm.AsmError;
 import sic.asm.Location;
+import sic.asm.Options;
 import sic.ast.Command;
 import sic.ast.data.*;
 import sic.ast.directives.*;
@@ -152,7 +153,7 @@ public class OperandParser {
             throw new AsmError(parser.loc(), "Invalid character '%c", parser.peek());
         // check for indexed addressing (only if simple)
         if (parser.skipIfIndexed()) {
-            if (flags.isSimple())
+            if (flags.isSimple() || flags.isIndirect() && Options.indirectX)
                 flags.setIndexed();
             else
                 throw new AsmError(parser.loc(), "Indexed addressing not supported here");
@@ -190,7 +191,7 @@ public class OperandParser {
             throw new AsmError(parser.loc(), "Invalid character '%c", parser.peek());
         // check for indexed addressing (only if simple)
         if (parser.skipIfIndexed()) {
-            if (flags.isSimple())
+            if (flags.isSimple() || flags.isIndirect() && Options.indirectX)
                 flags.setIndexed();
             else
                 throw new AsmError(parser.loc(), "Indexed addressing not supported here");


### PR DESCRIPTION
By design, SIC/XE does not allow indirect index addressing (@Label,X). With this commit, it can be bypassed optionally, while still not permitting it by default.
Since indirect addressing dereferences address twice, I have decided to add the index register after the first dereference. This behaviour is in my opinion the most logical possibility.
It can simplify many programs, especially manipulating C-like strings (pointer to character array).
Suppose you want to make print subroutine, which gets pointer to a string as an argument (in A register). Here, you can use index instead of tiresome arithmetic:
print	STA	ptr
	CLEAR	X
loop	LDCH	@ptr,X
	COMP	#0
	JEQ	halt
	WD	out
	TIX	#0
	J	loop
halt	J	halt
out	BYTE	1
ptr	RESW	1

You can enable it in assembler with `-indirect-x` flag.