### PR TITLE
removed syntax error on switch statement

### DIFF
--- a/src/sic/asm/parsing/Lexer.java
+++ b/src/sic/asm/parsing/Lexer.java
@@ -227,7 +227,7 @@ public class Lexer extends Input {
             if (c == '\\') {
                 c = advance();
                 switch (c) {
-                    case '\"', '\\':
+                    case '\"':
                         break;
                     case 'n':
                         c = '\n';


### PR DESCRIPTION
error when executing `make jar`

```
mkdir -p out/make
cd src; javac -encoding UTF-8 -d "../out/make" sic/Sim.java
./sic/asm/parsing/Lexer.java:230: error: : expected
                    case '\"', '\\':
                             ^
Note: ./sic/sim/views/components/treetable/JTreeTable.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: ./sic/asm/visitors/Visitor.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
make: *** [sim] Error 1
```

error resolved!

platform: macos arm64