### PR TITLE
fix linking M records with length 3

### DIFF
--- a/src/sic/link/visitors/SecondPassVisitor.java
+++ b/src/sic/link/visitors/SecondPassVisitor.java
@@ -85,7 +85,7 @@ public class SecondPassVisitor extends SectionVisitor {
             // each byte is 2 chars
             int start = (int)(fixAddressStart - fixRecord.getStartAddr()) * 2; // start of the addressed word
 
-            start = start + 6 - mRecord.getLength(); // last mRecord.getLength() halfbytes of the adressed word
+            start++;
             int end = start + mRecord.getLength();
 
             String text = fixRecord.getText();

--- a/src/sic/link/visitors/SecondPassVisitor.java
+++ b/src/sic/link/visitors/SecondPassVisitor.java
@@ -58,22 +58,22 @@ public class SecondPassVisitor extends SectionVisitor {
 
             // find the Trecord that has to be fixed
             TRecord fixRecord = null;
-			TRecord fixRecordEnd = null;
-			int found = 0;
+            TRecord fixRecordEnd = null;
+            int found = 0;
             if (currSection.getTRecords() != null) {
                 for (TRecord tRecord : currSection.getTRecords()) {
                     if (tRecord.contains(fixAddressStart)) {
-						found++;
+                        found++;
                         fixRecord = tRecord;
-						if (tRecord.contains(fixAddressEnd) || found == 2)
-							break;
+                        if (tRecord.contains(fixAddressEnd) || found == 2)
+                            break;
 
                     }
                     if (tRecord.contains(fixAddressEnd)) {
-						found++;
+                        found++;
                         fixRecordEnd = tRecord;
-						if (found == 2)
-							break;
+                        if (found == 2)
+                            break;
                     }
                 }
             }
@@ -89,10 +89,10 @@ public class SecondPassVisitor extends SectionVisitor {
             int end = start + mRecord.getLength();
 
             String text = fixRecord.getText();
-			int recordLength = text.length();
-			if (fixRecordEnd != null && fixRecord != fixRecordEnd) {
-				text += fixRecordEnd.getText();
-			}
+            int recordLength = text.length();
+            if (fixRecordEnd != null && fixRecord != fixRecordEnd) {
+                text += fixRecordEnd.getText();
+            }
 
             String fixBytes = text.substring(start, end);
 
@@ -109,10 +109,10 @@ public class SecondPassVisitor extends SectionVisitor {
 
             text = text.substring(0,start) + correctedString + text.substring(end);
             fixRecord.setText(text.substring(0,recordLength));
-			if (fixRecordEnd != null && fixRecord != fixRecordEnd) {
-				text = text.substring(recordLength);
-				fixRecordEnd.setText(text);
-			}
+            if (fixRecordEnd != null && fixRecord != fixRecordEnd) {
+                text = text.substring(recordLength);
+                fixRecordEnd.setText(text);
+            }
 
             if (options.isVerbose()) System.out.println("fixing " + mRecord.getLength() + " half-bytes from " + fixBytes + " to " + correctedString + "   symbol=" + symbol.getName());
 


### PR DESCRIPTION
This happens very rarely, that's what it may have gone unnoticed for so long.
It also raises additional concern. If the target symbol that the M record was referring to is relocated to some address, bigger than 2^12, it can't be properly modified. Is this a bug in assembler (we shouldn't use `bp=00` with the 3rd format, because it may get relocated later) or is this a mistake in specification?