### PR TITLE
fix a bug with obj-slack option

### DIFF
--- a/src/sic/asm/visitors/WriteText.java
+++ b/src/sic/asm/visitors/WriteText.java
@@ -33,7 +33,8 @@ public class WriteText extends WriteVisitor {
         if (recordBytes == 0) return;
         String codeString = buf.toString();
         while (recordBytes > 0) {
-            int length = codeString.length() <= 60 ? codeString.length() / 2 : 30;
+            String shortString = codeString.replace(" ", "");
+            int length = shortString.length() <= 60 ? shortString.length() / 2 : 30;
             w("T%s%06X%s%02X", space, textAddr, space, length);
             w(codeString.substring(0, length * 2));
             codeString = codeString.substring(length * 2);


### PR DESCRIPTION
Length of text record would be to high due to added spaces in codeString.

Note: this is duplicate of #43, I'm just changing my local git arrangement. Sorry for the unnecessary notification.