### PR TITLE
Runtime addon loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 SicTools.iml
 out
+addons/out
 /.project
 *.class
 tests/linker/factorial/factdemo.obj

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OUT = out/make
 
-all: outdir img
+all: outdir img addons
 	javac -encoding UTF-8 -sourcepath src -d "$(OUT)" src/sic/*.java
 
 sim: outdir img
@@ -14,6 +14,9 @@ asm: outdir
 
 link: outdir
 	javac -encoding UTF-8 -sourcepath src -d "$(OUT)" src/sic/Link.java
+
+addons: outdir
+	javac -encoding UTF-8 -sourcepath src -d "$(OUT)" src/sic/sim/addons/*/*.java
 
 jar: all
 	jar --create --file "$(OUT)/sictools.jar" --manifest MANIFEST.MF -C "$(OUT)" .

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Tools for SIC/XE hypothetical computer from the Leland Beck's book System Softwa
   * Simulator
   * Linker
 
+See also http://jurem.github.io/SicTools/ for the main page as well as https://github.com/jurem/SicDemos for several examples.
+
 ## Assembler
 Assembler supports all instructions and directives described in the book. This includes load/store instructions, arithmetic instructions, jumps etc. And directives START, END, ORG, LTORG, BASE, NOBASE, CSECT, USE, EQU, RESB, RESW, EXTDEF, EXTREF. Some features:
   * immediate addressing, indirect addressing, simple addressing
@@ -41,8 +43,43 @@ Linker supports linking .obj files produced by the assembler into one. Each obje
   * option to keep symbols in the output file to allow further linking
   * and more
 
+## Addons
+Simulator can be extended with external addons.
+They can provide additional devices, different ways of how the virtual processor can communicate with the host computer and much more.
 
-See also http://jurem.github.io/SicTools/ for the main page as well as https://github.com/jurem/SicDemos for several examples.
+### Usage
+Currently, addons can be loaded only via the cli with `-a path[@params]` argument.
+You can use as many `-a` arguments as there are addons you want to load.
+If the addon uses parametres, you can specify them after the addons path, separated by a `@` character.
+
+You can run the example addon (see [#examples](Examples) for building instructions) with the command
+    `java -cp out/make/sictools.jar sic.Sim -a addons/out/make/rand.jar@5`
+Loaded program can use the device `5` to read random bytes instead of file `05.dev`.
+
+### Writing an addon
+Addon is a jar file whose main class extends `sic.sim.addons.Addon` class.
+It can override any of the methods defined there according to its requirements.
+
+One of the most important methods is `init(sic.sim.Executor)`,
+with which the addon can obtain the simulator's executor object.
+The executor contains virtual machine, which can be used to access memory and registers.
+
+For more explanation, please read the code of the `Addon` class and see examples
+in `addons` and `src/sic/sim/addons` directories.
+
+#### Examples
+Directory `addons` contains an example of a standalone addon (intended use of addons),
+which can be build out of the source tree.
+You can build it with `name=rand make` command.
+
+When building your own addon, replace `rand` with the name of your addon.
+Also, don't forget to change `SICPATH` in Makefile according to location of your addon.
+
+Directory `src/sic/sim/addons` contains some other addons, which are built differently
+than a regular addon.
+They are included in the SicTools jar and loaded automatically,
+but can serve as more complex example of addons.
+
 
 Installation
 ------------

--- a/addons/Makefile
+++ b/addons/Makefile
@@ -1,0 +1,21 @@
+NAME=${name}
+# MAIN is the class which extends the abstract class sic.sim.plugins.Plugin.
+MAIN="${name}.Main"
+OUT=out/make
+# SICPATH should be changed if building from a different tree.
+# It can also point to sictools.jar file.
+SICPATH=../out/make
+
+
+.PHONY: main
+main: outdir
+	javac -encoding UTF-8 -cp ".:$(SICPATH)" -d "$(OUT)/$(NAME)" $(NAME)/*.java
+	jar --create --file "$(OUT)/$(NAME).jar" --main-class $(MAIN) -C "$(OUT)/$(NAME)" .
+
+.PHONY: outdir
+outdir:
+	@mkdir -p "$(OUT)"
+
+.PHONY: clean
+clean:
+	rm -rf "$(OUT)"

--- a/addons/rand/Main.java
+++ b/addons/rand/Main.java
@@ -1,0 +1,23 @@
+package rand;
+
+import java.util.Vector;
+
+import sic.sim.addons.Addon;
+import sic.sim.Executor;
+
+public class Main extends Addon {
+    private int device = 3;
+    public void load(String args) {
+        System.out.println("Loading rand");
+        if (args != null) {
+            device = Integer.parseInt(args);
+        }
+    }
+
+    @Override
+    public Vector<AddonDevice> getDevices() {
+        Vector<AddonDevice> vc = new Vector<AddonDevice>();
+        vc.add(new Addon.AddonDevice(device, new RandDevice(), true));
+        return vc;
+    }
+}

--- a/addons/rand/RandDevice.java
+++ b/addons/rand/RandDevice.java
@@ -1,0 +1,14 @@
+package rand;
+
+import java.util.Random;
+
+import sic.sim.vm.Device;
+
+public class RandDevice extends Device {
+    private Random random = new Random();
+
+    @Override
+    public int read() {
+        return random.nextInt(256);
+    }
+}

--- a/src/sic/Sim.java
+++ b/src/sic/Sim.java
@@ -54,6 +54,10 @@ public class Sim {
         }
 
         Vector<Addon> addons = new Vector<Addon>();
+        addons.add(AddonLoader.loadInternal("sic.sim.addons.stdio.Main"));
+        if (processedArgs.isTextScr()) {
+            addons.add(AddonLoader.loadInternal("sic.sim.addons.text.Main"));
+        }
 
         for (Args.AddonArgs a : processedArgs.getAddons()) {
             try {

--- a/src/sic/Sim.java
+++ b/src/sic/Sim.java
@@ -60,6 +60,11 @@ public class Sim {
             a.load(processedArgs.getTextScrPars());
             addons.add(a);
         }
+        if (processedArgs.isKeyb()) {
+            Addon a = AddonLoader.loadInternal("sic.sim.addons.keyboard.Keyboard");
+            a.load(processedArgs.getKeybPars());
+            addons.add(a);
+        }
 
         for (Args.AddonArgs a : processedArgs.getAddons()) {
             try {

--- a/src/sic/Sim.java
+++ b/src/sic/Sim.java
@@ -91,11 +91,11 @@ public class Sim {
             a.init(executor);
             machine.devices.setDevices(a.getDevices());
             mainView.addMenuEntries(a.getMenuEntries());
-            mainView.addTimerTasks(a.getTimerTasks());
+            mainView.addTimers(a.getTimers());
             mainView.addSettingsPanels(a.getSettingsPanels());
         }
         mainView.addAddonMenu();
-        mainView.updateTimerTasks();
+        mainView.updateTimers();
 
         if (processedArgs.hasFilename()) mainView.load(new File(processedArgs.getFilename()));
 

--- a/src/sic/Sim.java
+++ b/src/sic/Sim.java
@@ -56,7 +56,9 @@ public class Sim {
         Vector<Addon> addons = new Vector<Addon>();
         addons.add(AddonLoader.loadInternal("sic.sim.addons.stdio.Main"));
         if (processedArgs.isTextScr()) {
-            addons.add(AddonLoader.loadInternal("sic.sim.addons.text.Main"));
+            Addon a = AddonLoader.loadInternal("sic.sim.addons.text.TextualScreen");
+            a.load(processedArgs.getTextScrPars());
+            addons.add(a);
         }
 
         for (Args.AddonArgs a : processedArgs.getAddons()) {

--- a/src/sic/Sim.java
+++ b/src/sic/Sim.java
@@ -65,6 +65,11 @@ public class Sim {
             a.load(processedArgs.getKeybPars());
             addons.add(a);
         }
+        if (processedArgs.isGraphScr()) {
+            Addon a = AddonLoader.loadInternal("sic.sim.addons.graph.GraphicalScreen");
+            a.load(processedArgs.getGraphScrPars());
+            addons.add(a);
+        }
 
         for (Args.AddonArgs a : processedArgs.getAddons()) {
             try {

--- a/src/sic/Sim.java
+++ b/src/sic/Sim.java
@@ -6,11 +6,15 @@ import sic.sim.Args;
 import sic.sim.Executor;
 import sic.sim.MainView;
 import sic.sim.vm.Machine;
+import sic.sim.addons.Addon;
+import sic.sim.addons.AddonLoader;
 
 import javax.swing.UIManager;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
+import java.io.IOException;
+import java.util.Vector;
 
 /**
  * Simulator of the SIC/XE computer.
@@ -49,11 +53,38 @@ public class Sim {
             return;
         }
 
+        Vector<Addon> addons = new Vector<Addon>();
+
+        for (Args.AddonArgs a : processedArgs.getAddons()) {
+            try {
+                Addon p = AddonLoader.loadJar(a.path);
+                p.load(a.pars);
+                addons.add(p);
+            } catch (IOException e) {
+                System.out.printf("cannot open addon file %s%n", a.path);
+                System.out.println(e);
+                System.exit(1);
+            } catch (ClassCastException e) {
+                System.out.printf("main class of %s does not extend Addon class%n", a.path);
+                System.exit(1);
+            }
+        }
+
         Machine machine = new Machine();
         Executor executor = new Executor(machine, processedArgs);
         Disassembler disassembler = new Disassembler(new Mnemonics(), machine);
 
         final MainView mainView = new MainView(executor, disassembler, processedArgs);
+
+        for (Addon a : addons) {
+            a.init(executor);
+            machine.devices.setDevices(a.getDevices());
+            mainView.addMenuEntries(a.getMenuEntries());
+            mainView.addTimerTasks(a.getTimerTasks());
+            mainView.addSettingsPanels(a.getSettingsPanels());
+        }
+        mainView.addAddonMenu();
+        mainView.updateTimerTasks();
 
         if (processedArgs.hasFilename()) mainView.load(new File(processedArgs.getFilename()));
 

--- a/src/sic/Sim.java
+++ b/src/sic/Sim.java
@@ -54,22 +54,7 @@ public class Sim {
         }
 
         Vector<Addon> addons = new Vector<Addon>();
-        addons.add(AddonLoader.loadInternal("sic.sim.addons.stdio.Main"));
-        if (processedArgs.isTextScr()) {
-            Addon a = AddonLoader.loadInternal("sic.sim.addons.text.TextualScreen");
-            a.load(processedArgs.getTextScrPars());
-            addons.add(a);
-        }
-        if (processedArgs.isKeyb()) {
-            Addon a = AddonLoader.loadInternal("sic.sim.addons.keyboard.Keyboard");
-            a.load(processedArgs.getKeybPars());
-            addons.add(a);
-        }
-        if (processedArgs.isGraphScr()) {
-            Addon a = AddonLoader.loadInternal("sic.sim.addons.graph.GraphicalScreen");
-            a.load(processedArgs.getGraphScrPars());
-            addons.add(a);
-        }
+        loadInternalAddons(addons, processedArgs);
 
         for (Args.AddonArgs a : processedArgs.getAddons()) {
             try {
@@ -100,7 +85,6 @@ public class Sim {
             mainView.addSettingsPanels(a.getSettingsPanels());
         }
         mainView.addAddonMenu();
-        mainView.updateTimers();
 
         if (processedArgs.hasFilename()) mainView.load(new File(processedArgs.getFilename()));
 
@@ -116,5 +100,34 @@ public class Sim {
         if (processedArgs.isStart()) {
             executor.start();
         }
+    }
+
+    public static void loadInternalAddons(Vector<Addon> addons, Args args) {
+        addons.add(AddonLoader.loadInternal("sic.sim.addons.stdio.Main"));
+        Addon a = AddonLoader.loadInternal("sic.sim.addons.text.TextualScreen");
+        String pars = null;
+        if (args.isTextScr()) {
+            pars = args.getTextScrPars();
+        }
+        a.load(pars);
+        addons.add(a);
+
+        a = AddonLoader.loadInternal("sic.sim.addons.keyboard.Keyboard");
+        if (args.isKeyb()) {
+            pars = args.getKeybPars();
+        } else {
+            pars = null;
+        }
+        a.load(pars);
+        addons.add(a);
+
+        a = AddonLoader.loadInternal("sic.sim.addons.graph.GraphicalScreen");
+        if (args.isGraphScr()) {
+            pars = args.getGraphScrPars();
+        } else {
+            pars = null;
+        }
+        a.load(pars);
+        addons.add(a);
     }
 }

--- a/src/sic/VM.java
+++ b/src/sic/VM.java
@@ -5,7 +5,6 @@ import sic.loader.Loader;
 import sic.sim.Args;
 import sic.sim.Executor;
 import sic.sim.addons.GraphicalScreen;
-import sic.sim.addons.TextualScreen;
 import sic.sim.addons.Addon;
 import sic.sim.addons.AddonLoader;
 import sic.sim.vm.Machine;
@@ -40,7 +39,9 @@ public class VM {
         Vector<Addon> addons = new Vector<Addon>();
         addons.add(AddonLoader.loadInternal("sic.sim.addons.stdio.Main"));
         if (arg.isTextScr()) {
-            addons.add(AddonLoader.loadInternal("sic.sim.addons.text.Main"));
+            Addon a = AddonLoader.loadInternal("sic.sim.addons.text.TextualScreen");
+            a.load(arg.getTextScrPars());
+            addons.add(a);
         }
 
         for (Args.AddonArgs a : arg.getAddons()) {
@@ -78,14 +79,9 @@ public class VM {
             else Logger.fmterr("Invalid filename extension '%s'", ext);
         }
 
-        final TextualScreen textScreen = arg.isTextScr() ? new TextualScreen(executor) : null;
         final GraphicalScreen graphicalScreen = arg.isGraphScr() ? new GraphicalScreen(executor) : null;
 
         if (arg.isGraphScr() || arg.isTextScr()) {
-            if (textScreen != null) {
-                textScreen.setSize(arg.getTextScrCols(), arg.getTextScrRows());
-                textScreen.toggleView();
-            }
             if (graphicalScreen != null) {
                 graphicalScreen.setSize(arg.getGraphScrCols(), arg.getGraphScrRows());
                 graphicalScreen.toggleView();
@@ -94,12 +90,6 @@ public class VM {
             for (TimerTask t : timerTasks) {
                 timer.schedule(t, 0, 50);
             }
-            TimerTask timerTask = new TimerTask() {
-                public void run() {
-                    if (textScreen != null) textScreen.updateView();
-                }
-            };
-            timer.schedule(timerTask, 0, 50);
         }
 
         executor.start();

--- a/src/sic/VM.java
+++ b/src/sic/VM.java
@@ -38,6 +38,10 @@ public class VM {
         }
 
         Vector<Addon> addons = new Vector<Addon>();
+        addons.add(AddonLoader.loadInternal("sic.sim.addons.stdio.Main"));
+        if (arg.isTextScr()) {
+            addons.add(AddonLoader.loadInternal("sic.sim.addons.text.Main"));
+        }
 
         for (Args.AddonArgs a : arg.getAddons()) {
             try {

--- a/src/sic/VM.java
+++ b/src/sic/VM.java
@@ -2,6 +2,7 @@ package sic;
 
 import sic.common.Logger;
 import sic.loader.Loader;
+import sic.Sim;
 import sic.sim.Args;
 import sic.sim.Executor;
 import sic.sim.addons.Addon;
@@ -36,22 +37,7 @@ public class VM {
         }
 
         Vector<Addon> addons = new Vector<Addon>();
-        addons.add(AddonLoader.loadInternal("sic.sim.addons.stdio.Main"));
-        if (arg.isTextScr()) {
-            Addon a = AddonLoader.loadInternal("sic.sim.addons.text.TextualScreen");
-            a.load(arg.getTextScrPars());
-            addons.add(a);
-        }
-        if (arg.isKeyb()) {
-            Addon a = AddonLoader.loadInternal("sic.sim.addons.keyboard.Keyboard");
-            a.load(arg.getKeybPars());
-            addons.add(a);
-        }
-        if (arg.isGraphScr()) {
-            Addon a = AddonLoader.loadInternal("sic.sim.addons.graph.GraphicalScreen");
-            a.load(arg.getGraphScrPars());
-            addons.add(a);
-        }
+        Sim.loadInternalAddons(addons, arg);
 
         for (Args.AddonArgs a : arg.getAddons()) {
             try {

--- a/src/sic/VM.java
+++ b/src/sic/VM.java
@@ -67,13 +67,13 @@ public class VM {
         Machine machine = new Machine();
         Executor executor = new Executor(machine, arg);
 
-        Vector<TimerTask> timerTasks = new Vector<TimerTask>();
+        Vector<Addon.Timer> timers = new Vector<Addon.Timer>();
         for (Addon a : addons) {
             a.init(executor);
             machine.devices.setDevices(a.getDevices());
-            Vector<TimerTask> tasks = a.getTimerTasks();
+            Vector<Addon.Timer> tasks = a.getTimers();
             if (tasks != null) {
-                timerTasks.addAll(tasks);
+                timers.addAll(tasks);
             }
         }
 
@@ -84,16 +84,10 @@ public class VM {
             else Logger.fmterr("Invalid filename extension '%s'", ext);
         }
 
-        final GraphicalScreen graphicalScreen = arg.isGraphScr() ? new GraphicalScreen(executor) : null;
-
-        if (arg.isGraphScr() || arg.isTextScr()) {
-            if (graphicalScreen != null) {
-                graphicalScreen.setSize(arg.getGraphScrCols(), arg.getGraphScrRows());
-                graphicalScreen.toggleView();
-            }
+        if (timers.size() > 0) {
             java.util.Timer timer = new java.util.Timer();
-            for (TimerTask t : timerTasks) {
-                timer.schedule(t, 0, 50);
+            for (Addon.Timer t : timers) {
+                timer.schedule(t.task, 0, t.refreshMs);
             }
         }
 

--- a/src/sic/VM.java
+++ b/src/sic/VM.java
@@ -4,7 +4,6 @@ import sic.common.Logger;
 import sic.loader.Loader;
 import sic.sim.Args;
 import sic.sim.Executor;
-import sic.sim.addons.GraphicalScreen;
 import sic.sim.addons.Addon;
 import sic.sim.addons.AddonLoader;
 import sic.sim.vm.Machine;
@@ -46,6 +45,11 @@ public class VM {
         if (arg.isKeyb()) {
             Addon a = AddonLoader.loadInternal("sic.sim.addons.keyboard.Keyboard");
             a.load(arg.getKeybPars());
+            addons.add(a);
+        }
+        if (arg.isGraphScr()) {
+            Addon a = AddonLoader.loadInternal("sic.sim.addons.graph.GraphicalScreen");
+            a.load(arg.getGraphScrPars());
             addons.add(a);
         }
 

--- a/src/sic/VM.java
+++ b/src/sic/VM.java
@@ -43,6 +43,11 @@ public class VM {
             a.load(arg.getTextScrPars());
             addons.add(a);
         }
+        if (arg.isKeyb()) {
+            Addon a = AddonLoader.loadInternal("sic.sim.addons.keyboard.Keyboard");
+            a.load(arg.getKeybPars());
+            addons.add(a);
+        }
 
         for (Args.AddonArgs a : arg.getAddons()) {
             try {

--- a/src/sic/sim/Args.java
+++ b/src/sic/sim/Args.java
@@ -47,8 +47,7 @@ public class Args extends  AbstractCmdLineArgs {
     private boolean stats;
 
     private boolean textScr;
-    private int textScrCols;
-    private int textScrRows;
+    private String textScrPars;
 
     private boolean graphScr;
     private int graphScrCols;
@@ -100,12 +99,8 @@ public class Args extends  AbstractCmdLineArgs {
         return textScr;
     }
 
-    public int getTextScrCols() {
-        return textScrCols;
-    }
-
-    public int getTextScrRows() {
-        return textScrRows;
+    public String getTextScrPars() {
+        return textScrPars;
     }
 
     public boolean isGraphScr() {
@@ -151,12 +146,6 @@ public class Args extends  AbstractCmdLineArgs {
 
     int parseFreq(String s) {
         return Integer.parseInt(s);
-    }
-
-    void parseTextScreen(String s) {
-        int x = s.indexOf('x');
-        textScrCols = Integer.parseInt(s.substring(0, x));
-        textScrRows = Integer.parseInt(s.substring(x+1));
     }
 
     void parseGraphScreen(String s) {
@@ -223,7 +212,7 @@ public class Args extends  AbstractCmdLineArgs {
                     break;
                 case "-text":
                     textScr = true;
-                    parseTextScreen(args[++last]);
+                    textScrPars = args[++last];
                     break;
                 case "-graph":
                     graphScr = true;

--- a/src/sic/sim/Args.java
+++ b/src/sic/sim/Args.java
@@ -1,5 +1,7 @@
 package sic.sim;
 
+import java.util.Vector;
+
 import sic.common.Utils;
 
 /**
@@ -55,6 +57,8 @@ public class Args extends  AbstractCmdLineArgs {
 
     private boolean keyb;
     private int keybAddress;
+
+    private Vector<AddonArgs> addons = new Vector<AddonArgs>();
 
     public boolean isHelp() {
         return help;
@@ -128,6 +132,10 @@ public class Args extends  AbstractCmdLineArgs {
         return graphScrFreq;
     }
 
+    public Vector<AddonArgs> getAddons() {
+        return addons;
+    }
+
     public static void printArgs() {
         System.out.print(
             "    -help|-h              Print help.\n" +
@@ -137,7 +145,8 @@ public class Args extends  AbstractCmdLineArgs {
             "    -stats                Print instruction statistics.\n" +
             "    -text colsxrows       Show and resize textual screen.\n" +
             "    -graph colsxrows[@hz] Show and resize graphical screen.\n" +
-            "    -keyb address         Show and set keyboard address.\n");
+            "    -keyb address         Show and set keyboard address.\n" +
+            "    -a path[@params]      Load addon.\n");
     }
 
     int parseFreq(String s) {
@@ -179,6 +188,17 @@ public class Args extends  AbstractCmdLineArgs {
         }
     }
 
+    void parseAddon(String s) {
+        int i = s.indexOf('@');
+        String path = s;
+        String params = null;
+        if (i != -1) {
+            path = s.substring(0, i);
+            params = s.substring(i + 1);
+        }
+        addons.add(new AddonArgs(path, params));
+    }
+
     void processArgs(String[] args) {
         // options
         int last = 0;
@@ -213,6 +233,9 @@ public class Args extends  AbstractCmdLineArgs {
                     keyb = true;
                     parseKeyb(args[++last]);
                     break;
+                case "-a":
+                    parseAddon(args[++last]);
+                    break;
             }
             if (!arg.startsWith("-") || arg.equals("--")) break;
             last++;
@@ -229,4 +252,13 @@ public class Args extends  AbstractCmdLineArgs {
         processArgs(args);
     }
 
+    public class AddonArgs {
+        public String path;
+        public String pars;
+
+        public AddonArgs(String path, String pars) {
+            this.path = path;
+            this.pars = pars;
+        }
+    }
 }

--- a/src/sic/sim/Args.java
+++ b/src/sic/sim/Args.java
@@ -50,9 +50,7 @@ public class Args extends  AbstractCmdLineArgs {
     private String textScrPars;
 
     private boolean graphScr;
-    private int graphScrCols;
-    private int graphScrRows;
-    private int graphScrFreq;
+    private String graphScrPars;
 
     private boolean keyb;
     private String keybPars;
@@ -107,12 +105,8 @@ public class Args extends  AbstractCmdLineArgs {
         return graphScr;
     }
 
-    public int getGraphScrCols() {
-        return graphScrCols;
-    }
-
-    public int getGraphScrRows() {
-        return graphScrRows;
+    public String getGraphScrPars() {
+        return graphScrPars;
     }
 
     public boolean isKeyb(){
@@ -123,9 +117,6 @@ public class Args extends  AbstractCmdLineArgs {
         return keybPars;
     }
 
-    public int getGraphScrFreq() {
-        return graphScrFreq;
-    }
 
     public Vector<AddonArgs> getAddons() {
         return addons;
@@ -148,25 +139,6 @@ public class Args extends  AbstractCmdLineArgs {
         return Integer.parseInt(s);
     }
 
-    void parseGraphScreen(String s) {
-        int x = s.indexOf('x');
-        int at = s.indexOf('@');
-
-        String cols = s.substring(0, x);
-        String rows;
-        String hz;
-        if (at != -1) {
-            rows = s.substring(x + 1, at);
-            hz = s.substring(at + 1);
-        } else {
-            rows = s.substring(x + 1);
-            hz = "120";
-        }
-
-        graphScrCols = Integer.parseInt(cols);
-        graphScrRows = Integer.parseInt(rows);
-        graphScrFreq = Integer.parseInt(hz);
-    }
 
     void parseAddon(String s) {
         int i = s.indexOf('@');
@@ -207,7 +179,7 @@ public class Args extends  AbstractCmdLineArgs {
                     break;
                 case "-graph":
                     graphScr = true;
-                    parseGraphScreen(args[++last]);
+                    graphScrPars = args[++last];
                     break;
                 case "-keyb":
                     keyb = true;

--- a/src/sic/sim/Args.java
+++ b/src/sic/sim/Args.java
@@ -55,7 +55,7 @@ public class Args extends  AbstractCmdLineArgs {
     private int graphScrFreq;
 
     private boolean keyb;
-    private int keybAddress;
+    private String keybPars;
 
     private Vector<AddonArgs> addons = new Vector<AddonArgs>();
 
@@ -119,8 +119,8 @@ public class Args extends  AbstractCmdLineArgs {
         return keyb;
     }
 
-    public int getKeybAddress(){
-        return keybAddress;
+    public String getKeybPars(){
+        return keybPars;
     }
 
     public int getGraphScrFreq() {
@@ -168,15 +168,6 @@ public class Args extends  AbstractCmdLineArgs {
         graphScrFreq = Integer.parseInt(hz);
     }
 
-    void parseKeyb(String s){
-        keybAddress = 0xC000;
-        if(s.startsWith("0x")){
-            keybAddress = Integer.parseInt(s.substring(2), 16);
-        } else {
-            keybAddress = Integer.parseInt(s, 10);
-        }
-    }
-
     void parseAddon(String s) {
         int i = s.indexOf('@');
         String path = s;
@@ -220,7 +211,7 @@ public class Args extends  AbstractCmdLineArgs {
                     break;
                 case "-keyb":
                     keyb = true;
-                    parseKeyb(args[++last]);
+                    keybPars = args[++last];
                     break;
                 case "-a":
                     parseAddon(args[++last]);

--- a/src/sic/sim/MainView.java
+++ b/src/sic/sim/MainView.java
@@ -45,7 +45,6 @@ public class MainView {
 
     private Vector<Addon.MenuEntry> menuEntries = new Vector<Addon.MenuEntry>();
     private Vector<Addon.SettingsPanel> settingsPanels = new Vector<Addon.SettingsPanel>();
-    private Vector<Addon.Timer> timers = new Vector<Addon.Timer>();
 
     private Timer timer;
 
@@ -100,16 +99,10 @@ public class MainView {
     }
 
     public void addMenuEntries(Vector<Addon.MenuEntry> entries) {
-        if (entries == null) {
-            return;
-        }
         menuEntries.addAll(entries);
     }
 
     public void addSettingsPanels(Vector<Addon.SettingsPanel> panels) {
-        if (panels == null) {
-            return;
-        }
         settingsPanels.addAll(panels);
     }
 
@@ -124,17 +117,11 @@ public class MainView {
             GUI.addMenuItem(menu, e.name, e.keyEvent, e.keyStroke, e.actionListener);
         }
         mb.add(menu);
+        mb.validate();
     }
 
     public void addTimers(Vector<Addon.Timer> tasks) {
-        if (tasks == null) {
-            return;
-        }
-        timers.addAll(tasks);
-    }
-
-    public void updateTimers() {
-        for (Addon.Timer t : timers) {
+        for (Addon.Timer t : tasks) {
             timer.schedule(t.task, 0, t.refreshMs);
         }
     }

--- a/src/sic/sim/MainView.java
+++ b/src/sic/sim/MainView.java
@@ -12,7 +12,6 @@ import sic.link.ui.LinkerGui;
 import sic.loader.Loader;
 import sic.sim.addons.GraphicalScreen;
 import sic.sim.addons.Keyboard;
-import sic.sim.addons.TextualScreen;
 import sic.sim.views.*;
 import sic.sim.addons.Addon;
 
@@ -42,7 +41,6 @@ public class MainView {
     private MemoryView memoryView;
     private WatchView watchView;
     // addon views
-    private TextualScreen textScreen;
     private GraphicalScreen graphScreen;
     private Keyboard keyboard;
     private DataBreakpointView dataBreakpointView;
@@ -86,14 +84,9 @@ public class MainView {
         mainFrame.setLocation(0, 0);
         mainFrame.setVisible(true);
 
-        textScreen = new TextualScreen(executor);
         graphScreen = new GraphicalScreen(executor);
         keyboard = new Keyboard(executor);
 
-        if (arg.isTextScr()) {
-            textScreen.setSize(arg.getTextScrCols(), arg.getTextScrRows());
-            textScreen.toggleView();
-        }
         if (arg.isGraphScr()) {
             graphScreen.setSize(arg.getGraphScrCols(), arg.getGraphScrRows());
             graphScreen.toggleView();
@@ -109,7 +102,6 @@ public class MainView {
                 if (mainFrame.isVisible() && executor.hasChanged()) {
                     updateView();
                 }
-                textScreen.updateView();
             }
         };
         timer.schedule(timerTask, 0, 50);
@@ -124,6 +116,7 @@ public class MainView {
             }
         }, 0, refreshMs);
     }
+
 
     public void updateView() {
         cpuView.updateView();
@@ -326,12 +319,6 @@ public class MainView {
 
         // View
         menu = new JMenu("View");
-        GUI.addMenuItem(menu, "Textual screen", KeyEvent.VK_T, KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.CTRL_DOWN_MASK), new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent actionEvent) {
-                textScreen.toggleView();
-            }
-        });
         GUI.addMenuItem(menu, "Graphical screen", KeyEvent.VK_G, KeyStroke.getKeyStroke(KeyEvent.VK_G, InputEvent.CTRL_DOWN_MASK), new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
@@ -437,7 +424,6 @@ public class MainView {
     private void showSettingsView() {
         JTabbedPane tabs = new JTabbedPane(JTabbedPane.TOP);
         tabs.addTab("General", null, createSettingsGeneralPane(), null);
-        tabs.addTab("Textual screen", null, textScreen.createSettingsPane(), null);
         tabs.addTab("Graphical screen", null, graphScreen.createSettingsPane(), null);
         tabs.addTab("Keyboard", null, keyboard.createSettingsPane(), null);
         for (Addon.SettingsPanel panel : settingsPanels) {

--- a/src/sic/sim/MainView.java
+++ b/src/sic/sim/MainView.java
@@ -11,7 +11,6 @@ import sic.link.ui.LinkListener;
 import sic.link.ui.LinkerGui;
 import sic.loader.Loader;
 import sic.sim.addons.GraphicalScreen;
-import sic.sim.addons.Keyboard;
 import sic.sim.views.*;
 import sic.sim.addons.Addon;
 
@@ -42,7 +41,6 @@ public class MainView {
     private WatchView watchView;
     // addon views
     private GraphicalScreen graphScreen;
-    private Keyboard keyboard;
     private DataBreakpointView dataBreakpointView;
 
     private File lastLoadedFile;
@@ -85,15 +83,10 @@ public class MainView {
         mainFrame.setVisible(true);
 
         graphScreen = new GraphicalScreen(executor);
-        keyboard = new Keyboard(executor);
 
         if (arg.isGraphScr()) {
             graphScreen.setSize(arg.getGraphScrCols(), arg.getGraphScrRows());
             graphScreen.toggleView();
-        }
-        if(arg.isKeyb()){
-            keyboard.setScreen(SICXE.intToAddr(arg.getKeybAddress()));
-            keyboard.toggleView();
         }
 
         timer = new Timer();
@@ -325,12 +318,6 @@ public class MainView {
                 graphScreen.toggleView();
             }
         });
-        GUI.addMenuItem(menu, "Keyboard", KeyEvent.VK_K, KeyStroke.getKeyStroke(KeyEvent.VK_K, InputEvent.CTRL_DOWN_MASK), new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent actionEvent) {
-                keyboard.toggleView();
-            }
-        });
         menu.addSeparator();
         GUI.addMenuItem(menu, "Data breakpoints", KeyEvent.VK_D, KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.CTRL_DOWN_MASK), new ActionListener() {
             @Override
@@ -425,7 +412,6 @@ public class MainView {
         JTabbedPane tabs = new JTabbedPane(JTabbedPane.TOP);
         tabs.addTab("General", null, createSettingsGeneralPane(), null);
         tabs.addTab("Graphical screen", null, graphScreen.createSettingsPane(), null);
-        tabs.addTab("Keyboard", null, keyboard.createSettingsPane(), null);
         for (Addon.SettingsPanel panel : settingsPanels) {
             tabs.addTab(panel.title, null, panel.panel, null);
         }

--- a/src/sic/sim/addons/Addon.java
+++ b/src/sic/sim/addons/Addon.java
@@ -1,0 +1,76 @@
+package sic.sim.addons;
+
+import java.awt.event.ActionListener;
+import java.util.TimerTask;
+import java.util.Vector;
+
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+
+import sic.sim.vm.Device;
+import sic.sim.Executor;
+import sic.sim.MainView;
+
+public abstract class Addon {
+    // Mehtod load is called immediately after the addon has been loaded.
+    public void load(String params) {
+        System.out.println("loading addon with parametres: " + params);
+    }
+
+    // Method init is called after the executor and graphical simulator
+    // (for sic.Sim) have been initialized.
+    public void init(Executor executor) {}
+
+    public Vector<AddonDevice> getDevices() {
+        return null;
+    }
+
+    public static class AddonDevice {
+        public int name;
+        public Device dev;
+        public boolean force;
+        public AddonDevice(int name, Device dev, boolean force) {
+            this.name = name;
+            this.dev = dev;
+            this.force = force;
+        }
+    }
+
+    // TimerTasks are executed at constant rate, when the graphical
+    // simulator is refreshed.
+    public Vector<TimerTask> getTimerTasks() {
+        return null;
+    }
+
+    // MenuEntries are added to the "Addons" menu in the menu bar.
+    public Vector<MenuEntry> getMenuEntries() {
+        return null;
+    }
+
+    public static class MenuEntry {
+        public String name;
+        public int keyEvent;
+        public KeyStroke keyStroke;
+        public ActionListener actionListener;
+        public MenuEntry(String name, int keyEvent, KeyStroke keyStroke, ActionListener actionListener) {
+            this.name = name;
+            this.keyEvent = keyEvent;
+            this.keyStroke = keyStroke;
+            this.actionListener = actionListener;
+        }
+    }
+
+    // SettingsPanels are added as tabs to the settings window.
+    public Vector<SettingsPanel> getSettingsPanels() {
+        return null;
+    }
+
+    public static class SettingsPanel {
+        public String title;
+        public JPanel panel;
+        public SettingsPanel(String title, JPanel panel) {
+            this.title = title;
+            this.panel = panel;
+        }
+    }
+}

--- a/src/sic/sim/addons/Addon.java
+++ b/src/sic/sim/addons/Addon.java
@@ -36,10 +36,18 @@ public abstract class Addon {
         }
     }
 
-    // TimerTasks are executed at constant rate, when the graphical
-    // simulator is refreshed.
-    public Vector<TimerTask> getTimerTasks() {
+    // Timers execute their tasks at constant rate.
+    public Vector<Timer> getTimers() {
         return null;
+    }
+
+    public static class Timer {
+        public TimerTask task;
+        public long refreshMs;
+        public Timer(TimerTask task, long refreshMs) {
+            this.task = task;
+            this.refreshMs = refreshMs;
+        }
     }
 
     // MenuEntries are added to the "Addons" menu in the menu bar.

--- a/src/sic/sim/addons/Addon.java
+++ b/src/sic/sim/addons/Addon.java
@@ -26,7 +26,7 @@ public abstract class Addon {
     public void init(Executor executor) {}
 
     public Vector<AddonDevice> getDevices() {
-        return null;
+        return new Vector<AddonDevice>();
     }
 
     public static class AddonDevice {
@@ -42,7 +42,7 @@ public abstract class Addon {
 
     // Timers execute their tasks at constant rate.
     public Vector<Timer> getTimers() {
-        return null;
+        return new Vector<Timer>();
     }
 
     public static class Timer {
@@ -56,7 +56,7 @@ public abstract class Addon {
 
     // MenuEntries are added to the "Addons" menu in the menu bar.
     public Vector<MenuEntry> getMenuEntries() {
-        return null;
+        return new Vector<MenuEntry>();
     }
 
     public static class MenuEntry {
@@ -74,7 +74,7 @@ public abstract class Addon {
 
     // SettingsPanels are added as tabs to the settings window.
     public Vector<SettingsPanel> getSettingsPanels() {
-        return null;
+        return new Vector<SettingsPanel>();
     }
 
     public static class SettingsPanel {

--- a/src/sic/sim/addons/Addon.java
+++ b/src/sic/sim/addons/Addon.java
@@ -13,8 +13,12 @@ import sic.sim.MainView;
 
 public abstract class Addon {
     // Mehtod load is called immediately after the addon has been loaded.
+    // When params are not specified (user ommited '@' when loading the addon),
+    // the argument 'param' is null.
     public void load(String params) {
-        System.out.println("loading addon with parametres: " + params);
+        if (params != null) {
+            System.out.println("loading addon with parametres: " + params);
+        }
     }
 
     // Method init is called after the executor and graphical simulator
@@ -28,7 +32,7 @@ public abstract class Addon {
     public static class AddonDevice {
         public int name;
         public Device dev;
-        public boolean force;
+        public boolean force; // currently unused
         public AddonDevice(int name, Device dev, boolean force) {
             this.name = name;
             this.dev = dev;

--- a/src/sic/sim/addons/AddonLoader.java
+++ b/src/sic/sim/addons/AddonLoader.java
@@ -1,0 +1,77 @@
+package sic.sim.addons;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Vector;
+import java.util.jar.Attributes;
+
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class AddonLoader extends URLClassLoader {
+    private URL url;
+    public AddonLoader(URL url) {
+        super(new URL[] {url});
+        this.url = url;
+    }
+
+    public String getMainClassName() throws IOException {
+        URL u = new URL("jar", "", url + "!/");
+        JarURLConnection uc = (JarURLConnection)u.openConnection();
+        Attributes attr = uc.getMainAttributes();
+        return attr != null ? attr.getValue(Attributes.Name.MAIN_CLASS) : null;
+    }
+
+    private static Addon loadAddon(String className, ClassLoader cl) {
+        try {
+            Class<?> c = cl.loadClass(className);
+            Class<? extends Addon> addonClass = c.asSubclass(Addon.class);
+            Constructor<? extends Addon> constructor = addonClass.getConstructor();
+            Addon a =  constructor.newInstance();
+            return a;
+        } catch (NoSuchMethodException e) {
+            System.out.println(e);
+            System.exit(1);
+        } catch (InstantiationException e) {
+            System.out.println(e);
+            System.exit(1);
+        } catch (IllegalAccessException e) {
+            System.out.println(e);
+            System.exit(1);
+        } catch (InvocationTargetException e) {
+            System.out.println(e);
+            System.exit(1);
+        } catch (ClassNotFoundException e) {
+            System.out.println("should not happen");
+            System.out.println(e);
+            System.exit(1);
+        }
+        return null;
+    }
+
+    public static Addon loadJar(String filepath) throws IOException {
+        try {
+            if (!filepath.endsWith(".jar")) {
+                filepath = filepath + ".jar";
+            }
+            File addon = new File(filepath);
+            AddonLoader jarLoader = new AddonLoader(addon.toURI().toURL());
+            String className;
+            className = jarLoader.getMainClassName();
+            return loadAddon(className, jarLoader);
+        } catch (MalformedURLException e) {
+            System.out.println(e);
+        }
+        return null;
+    }
+
+    public static Addon loadInternal(String className) {
+        ClassLoader cl = AddonLoader.class.getClassLoader();
+        return loadAddon(className, cl);
+    }
+}

--- a/src/sic/sim/addons/graph/GraphicalScreen.java
+++ b/src/sic/sim/addons/graph/GraphicalScreen.java
@@ -39,6 +39,7 @@ public class GraphicalScreen extends Addon {
     private int pixelSize = PIXELSIZE;
     private int freq = 120;
     // gui
+    private boolean visible = false; // only used at loading time
     private JFrame view;
     private JPanel pnlScreen;
 
@@ -62,6 +63,7 @@ public class GraphicalScreen extends Addon {
             cols = Integer.parseInt(sCols);
             rows = Integer.parseInt(sRows);
             freq = Integer.parseInt(hz);
+            visible = true;
         }
     }
 
@@ -71,7 +73,9 @@ public class GraphicalScreen extends Addon {
         this.view = createView();
         setScreen(address, cols, rows, pixelSize);
         //setSize(arg.getGraphScrCols(), arg.getGraphScrRows());
-        toggleView();
+        if (visible) {
+            toggleView();
+        }
     }
 
     @Override

--- a/src/sic/sim/addons/keyboard/Keyboard.java
+++ b/src/sic/sim/addons/keyboard/Keyboard.java
@@ -31,16 +31,18 @@ public class Keyboard extends Addon {
     public final int ADDRESS = 0xC000;
 
     private Memory memory;
-    // gui
-    private JFrame view;
     // settings
     private int address = ADDRESS;
+    // gui
+    private boolean visible = false; // only used at loading time
+    private JFrame view;
     private JTextArea inputArea;
 
     @Override
     public void load(String args) {
         if (args != null) {
             address = Integer.decode(args);
+            visible = true;
         }
     }
 
@@ -49,7 +51,9 @@ public class Keyboard extends Addon {
         this.memory = executor.getMachine().memory;
         this.view = createView();
         setScreen(address);
-        toggleView();
+        if (visible) {
+            toggleView();
+        }
     }
 
     @Override
@@ -115,8 +119,7 @@ public class Keyboard extends Addon {
         panel.add(bevel);
 
         JFrame frame = new JFrame("Keyboard");
-//        frame.setResizable(false);
-//        frame.setBounds(620, 370, 500, 300);
+        frame.setResizable(false);
         frame.setContentPane(panel);
 
         return frame;

--- a/src/sic/sim/addons/keyboard/Keyboard.java
+++ b/src/sic/sim/addons/keyboard/Keyboard.java
@@ -1,4 +1,4 @@
-package sic.sim.addons;
+package sic.sim.addons.keyboard;
 
 import sic.common.Conversion;
 import sic.common.GUI;
@@ -6,6 +6,7 @@ import sic.common.SICXE;
 import sic.common.Logger;
 import sic.sim.Executor;
 import sic.sim.vm.Memory;
+import sic.sim.addons.Addon;
 
 import javax.swing.*;
 import javax.swing.border.BevelBorder;
@@ -13,8 +14,11 @@ import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.util.Vector;
+
 
 /**
  * Keyboard addon for SicTools
@@ -22,21 +26,49 @@ import java.awt.event.KeyListener;
  * Stores character value of latest key press into the memory
  * The Keyboard window has to be opened and focused
  */
-public class Keyboard {
+public class Keyboard extends Addon {
 
     public final int ADDRESS = 0xC000;
 
-    private final Memory memory;
+    private Memory memory;
     // gui
-    private final JFrame view;
+    private JFrame view;
     // settings
-    private int address;
+    private int address = ADDRESS;
     private JTextArea inputArea;
 
-    public Keyboard(final Executor executor) {
+    @Override
+    public void load(String args) {
+        if (args != null) {
+            address = Integer.decode(args);
+        }
+    }
+
+    @Override
+    public void init(Executor executor) {
         this.memory = executor.getMachine().memory;
         this.view = createView();
-        setScreen(ADDRESS);
+        setScreen(address);
+        toggleView();
+    }
+
+    @Override
+    public Vector<MenuEntry> getMenuEntries() {
+        Vector<MenuEntry> es = new Vector<MenuEntry>();
+        es.add(new MenuEntry("Toggle keyboard", KeyEvent.VK_K, KeyStroke.getKeyStroke(KeyEvent.VK_K, InputEvent.CTRL_DOWN_MASK), new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                toggleView();
+            }
+        }));
+        return es;
+    }
+
+    @Override
+    public Vector<SettingsPanel> getSettingsPanels() {
+        Vector<SettingsPanel> panels = new Vector<SettingsPanel>();
+        panels.add(new SettingsPanel("Keyboard", createSettingsPane()));
+        return panels;
     }
 
     public void setSize(int cols, int rows) {
@@ -63,7 +95,7 @@ public class Keyboard {
             public void keyPressed(KeyEvent e) {
                 e.consume();
                 int value = (Character.toUpperCase(e.getKeyChar()) & 0xFF);
-                inputArea.setText(String.format("%c => %c (%d) ", e.getKeyChar(), (char)value, value));
+                inputArea.setText(String.format("%c => %c (%x) ", e.getKeyChar(), (char)value, value));
                 memory.setByteRaw(address, value);
             }
 

--- a/src/sic/sim/addons/stdio/InputDevice.java
+++ b/src/sic/sim/addons/stdio/InputDevice.java
@@ -1,7 +1,9 @@
-package sic.sim.vm;
+package sic.sim.addons.stdio;
 
 import java.io.IOException;
 import java.io.InputStream;
+
+import sic.sim.vm.Device;
 
 /**
  * Device which supports reading from InputStream, e.g. System.in

--- a/src/sic/sim/addons/stdio/Main.java
+++ b/src/sic/sim/addons/stdio/Main.java
@@ -1,0 +1,18 @@
+package sic.sim.addons.stdio;
+
+import java.util.Vector;
+
+import sic.sim.addons.Addon;
+import sic.sim.Executor;
+import sic.common.SICXE;
+
+public class Main extends Addon {
+    @Override
+    public Vector<AddonDevice> getDevices() {
+        Vector<AddonDevice> vc = new Vector<AddonDevice>();
+        vc.add(new Addon.AddonDevice(SICXE.DEVICE_STDIN, new InputDevice(System.in), true));
+        vc.add(new Addon.AddonDevice(SICXE.DEVICE_STDOUT, new OutputDevice(System.out), true));
+        vc.add(new Addon.AddonDevice(SICXE.DEVICE_STDERR, new OutputDevice(System.err), true));
+        return vc;
+    }
+}

--- a/src/sic/sim/addons/stdio/OutputDevice.java
+++ b/src/sic/sim/addons/stdio/OutputDevice.java
@@ -1,7 +1,9 @@
-package sic.sim.vm;
+package sic.sim.addons.stdio;
 
 import java.io.IOException;
 import java.io.OutputStream;
+
+import sic.sim.vm.Device;
 
 /**
  * Device supporting writing to OutputStream, e.g. System.out.

--- a/src/sic/sim/addons/text/TextualScreen.java
+++ b/src/sic/sim/addons/text/TextualScreen.java
@@ -27,8 +27,8 @@ import java.util.Vector;
  */
 public class TextualScreen extends Addon {
     public final int ADDRESS = 0xB800;
-    public final int COLS = 80;
-    public final int ROWS = 25;
+    public final int COLS = 25;
+    public final int ROWS = 80;
     public final int FONTSIZE = 12;
 
     private Memory memory;
@@ -37,6 +37,7 @@ public class TextualScreen extends Addon {
     private int rows = COLS;
     private int cols = ROWS;
     // gui
+    private boolean visible = false; // only used at loading time
     private JFrame view;
     private JTextArea txtScreen;
 
@@ -46,6 +47,7 @@ public class TextualScreen extends Addon {
             int x = pars.indexOf('x');
             cols = Integer.parseInt(pars.substring(0, x));
             rows = Integer.parseInt(pars.substring(x+1));
+            visible = true;
         }
     }
 
@@ -54,7 +56,9 @@ public class TextualScreen extends Addon {
         this.memory = executor.getMachine().memory;
         this.view = createView();
         setScreen(address, cols, rows, FONTSIZE);
-        toggleView();
+        if (visible) {
+            toggleView();
+        }
     }
 
     @Override

--- a/src/sic/sim/addons/text/TextualScreen.java
+++ b/src/sic/sim/addons/text/TextualScreen.java
@@ -58,14 +58,14 @@ public class TextualScreen extends Addon {
     }
 
     @Override
-    public Vector<TimerTask> getTimerTasks() {
-        Vector<TimerTask> tts = new Vector<TimerTask>();
-        tts.add(new TimerTask() {
+    public Vector<Timer> getTimers() {
+        Vector<Timer> ts = new Vector<Timer>();
+        ts.add(new Timer(new TimerTask() {
             public void run() {
                 updateView();
             }
-        });
-        return tts;
+        }, 50));
+        return ts;
     }
 
     @Override

--- a/src/sic/sim/addons/text/TextualScreen.java
+++ b/src/sic/sim/addons/text/TextualScreen.java
@@ -1,10 +1,11 @@
-package sic.sim.addons;
+package sic.sim.addons.text;
 
 import sic.common.Conversion;
 import sic.common.GUI;
 import sic.common.SICXE;
 import sic.sim.Executor;
 import sic.sim.vm.Memory;
+import sic.sim.addons.Addon;
 
 import javax.swing.*;
 import javax.swing.border.BevelBorder;
@@ -12,34 +13,80 @@ import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.TimerTask;
+import java.util.Vector;
 
 /**
  * TODO: write a short description
  *
  * @author jure
  */
-public class TextualScreen {
+public class TextualScreen extends Addon {
     public final int ADDRESS = 0xB800;
     public final int COLS = 80;
     public final int ROWS = 25;
     public final int FONTSIZE = 12;
 
-    private final Memory memory;
+    private Memory memory;
     // settings
-    private int address;
-    private int rows;
-    private int cols;
+    private int address = ADDRESS;
+    private int rows = COLS;
+    private int cols = ROWS;
     // gui
-    private final JFrame view;
+    private JFrame view;
     private JTextArea txtScreen;
 
-    public TextualScreen(final Executor executor) {
+    @Override
+    public void load(String pars) {
+        if (pars != null) {
+            int x = pars.indexOf('x');
+            cols = Integer.parseInt(pars.substring(0, x));
+            rows = Integer.parseInt(pars.substring(x+1));
+        }
+    }
+
+    @Override
+    public void init(Executor executor) {
         this.memory = executor.getMachine().memory;
         this.view = createView();
-        setScreen(ADDRESS, COLS, ROWS, FONTSIZE);
+        setScreen(address, cols, rows, FONTSIZE);
+        toggleView();
     }
+
+    @Override
+    public Vector<TimerTask> getTimerTasks() {
+        Vector<TimerTask> tts = new Vector<TimerTask>();
+        tts.add(new TimerTask() {
+            public void run() {
+                updateView();
+            }
+        });
+        return tts;
+    }
+
+    @Override
+    public Vector<MenuEntry> getMenuEntries() {
+        Vector<MenuEntry> es = new Vector<MenuEntry>();
+        es.add(new MenuEntry("Toggle textual screen", KeyEvent.VK_T, KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.CTRL_DOWN_MASK), new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                toggleView();
+            }
+        }));
+        return es;
+    }
+
+    @Override
+    public Vector<SettingsPanel> getSettingsPanels() {
+        Vector<SettingsPanel> panels = new Vector<SettingsPanel>();
+        panels.add(new SettingsPanel("Textual screen", createSettingsPane()));
+        return panels;
+    }
+
 
     public void clearScreen() {
         for (int i = 0; i < rows; i++)
@@ -59,7 +106,6 @@ public class TextualScreen {
         this.cols = cols;
         txtScreen.setRows(rows);
         txtScreen.setColumns(cols);
-//        txtScreen.setFont(new java.awt.Font("Courier New", java.awt.Font.BOLD, fontSize));
         txtScreen.setFont(new Font("monospaced", Font.BOLD, fontSize));
         updateView();
         view.pack();
@@ -91,7 +137,7 @@ public class TextualScreen {
 
         JFrame frame = new JFrame("Screen");
         frame.setResizable(false);
-//        frame.setBounds(620, 370, 500, 300);
+        //        frame.setBounds(620, 370, 500, 300);
         frame.setContentPane(panel);
 
         return frame;

--- a/src/sic/sim/vm/Devices.java
+++ b/src/sic/sim/vm/Devices.java
@@ -1,8 +1,11 @@
 package sic.sim.vm;
 
+import java.util.Vector;
+
 import sic.common.Conversion;
 import sic.common.Logger;
 import sic.common.SICXE;
+import sic.sim.addons.Addon;
 
 /**
  * @author jure
@@ -54,6 +57,15 @@ public class Devices {
     public void reset() {
         for (int i = SICXE.DEVICE_FREE; i < devices.length; i++) {
             devices[i].reset();
+        }
+    }
+
+    public void setDevices(Vector<Addon.AddonDevice> devices) {
+        if (devices == null) {
+            return;
+        }
+        for (Addon.AddonDevice d : devices) {
+            setDevice(d.name, d.dev);
         }
     }
 

--- a/src/sic/sim/vm/Devices.java
+++ b/src/sic/sim/vm/Devices.java
@@ -72,10 +72,7 @@ public class Devices {
     public Devices(int count) {
         assert count > 2;
         devices = new Device[count];
-        setDevice(SICXE.DEVICE_STDIN, new InputDevice(System.in));
-        setDevice(SICXE.DEVICE_STDOUT, new OutputDevice(System.out));
-        setDevice(SICXE.DEVICE_STDERR, new OutputDevice(System.err));
-        for (int i = SICXE.DEVICE_FREE; i < count; i++)
+        for (int i = 0; i < count; i++)
             setDevice(i, new FileDevice(Conversion.byteToHex(i) + ".dev"));
     }
 


### PR DESCRIPTION
I've implemented a proof-of-concept of dynamic addon loading and I'm submitting it for comments, since the design cold be imporved.

# Addons
Addons are standalone jars, loaded at runtime. They can be developed independently of the simulator and can provide some additional functionality.

An example addon is shown in `addons/rand`. When building a jar file, main class should extend abstract class `sic.sim.addons.Addon`. Only the methods, needed for functinality of the addon, have to be overriden.

The abstract class Addon currently contains methods for initializing the addon and some other methods (documented in the source file itself). The class could be extended at any time (with non-abstract methods) without breaking any older addons.

Addons can be loaded with `-a path[@params]` command line options. Parametres are passed to the `load` method of the loaded addon.

There are currently two ways addons can interacti with the simulator:
1. Through the `Executor` object, given as a parametre to the `init` method.
2. Through other methods, which return a list of "things", the addon wants to have integrated into the simulator. For example, with `getDevices` method we can return a list of devices and their address. Then the simulator adds them to the list of devices.

## Internal addons
I've also moved the first three devices (stdin/out/err) and textual screen to an internal addon (graphical screen and keyboard could be next). Internal addons are also loaded at runtime but they are bundled in the sictools jar. Although I'm not sure if this is even reasonable.
We could do two things regarding those internal addons:
1. Revert those changes; then those components would be coupled with the simulator as before.
2. Or move them to completely external addons. I would like to do this, but the drawback is lack of backwards compatibility. Maybe a new major version would be enough to allow such breaking changes.

## Testing
You can test an example addon by compiling it first. Run `name=rand make` inside `addons` directory.
Then run an [example code](https://gist.github.com/Kljunas2/06d127da43500f7d3323c2aed9725399)
`java -cp sictools.jar sic.VM -a <path/to/rand.jar> random.asm`
It should output hexadecimal representation of random bytes.

## Future development
Are there improvements to be made to the `Addons` class? Or maybe to the cli interaction with addons loader?
As mentioned before, graphical screen and keyboard could be moved to addon.
There could also be some way to choose addons to load in the GUI.